### PR TITLE
README update for Windows and Unix binary directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # glance
 A simple, and efficient image viewer written in GTK 3 and D.
 
-## Usage on Windows
-Currently, there is no support for `glance` on Windows. If you wish to add it, you may fork the repo and add it yourself. If you want to build it using WSL, follow the Linux/OSX instructions below and adjust accordingly to distribution (eg Ubuntu on Windows).
-
 ## Usage on Linux/OSX 
 ```
 dub build
@@ -11,9 +8,12 @@ chmod +x glance
 glance
 ```
 
-By default, running this command will produce a file called `glance` in the folder `glance`, if you wish to use this commonly it may be useful to either symlink or copy it to `/usr/bin`.
+By default, running this command will produce a file called `glance` in the folder `glance`, if you wish to use this commonly it may be useful to either symlink or copy it to `/usr/local/bin`.
 
-To copy it, you can run `cp glance /usr/bin/glance`.
+To copy it, you can run `cp glance /usr/local/bin/glance`.
+
+## Usage on Windows
+Complete the setup for [GtkD on Windows](https://github.com/gtkd-developers/GtkD/wiki/Installing-on-Windows) and run `dub build` as normal. `glance.exe` will be built and is runnable as long as the GtkD runtime is installed on the system.
 
 ## Contributing
 Read `CONTRIBUTING` for more information about how to contribute to `glance`.


### PR DESCRIPTION
Added Windows build instructions and changed the recommended install directory for Unix to `/usr/local/bin`